### PR TITLE
⬆️  Update to Java 17

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.0] - 2023-05-22
+### Changed
+- Update to Java 17
+
 ## [v1.3.2] - 2023-04-04
 ### Changed
 - Update flutter version to 3.7.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update && apt-get install -y \
 
 RUN curl -s "https://get.sdkman.io" | bash && \
     source "$HOME/.sdkman/bin/sdkman-init.sh" && \
-    sdk install java 11.0.10-zulu && \
-    sdk use java 11.0.10-zulu
+    sdk install java 17.0.7-oracle && \
+    sdk use java 17.0.7-oracle
 
 ENV JAVA_HOME /root/.sdkman/candidates/java/current
 ENV ANDROID_HOME /opt/android-sdk-linux

--- a/README.MD
+++ b/README.MD
@@ -3,7 +3,7 @@
 This Docker image serves as an environment for running Android builds on Gitlab CI in Ackee workspace.
 
 Contains:
-- Java 11 environment
+- Java 17 environment
 - NVM with default node version to 12.2.0
 - Latest 8 Android version SDKs + Platform CLI tools
 - gcloud CLI tool


### PR DESCRIPTION
We need to update Java to 17, which is required by the latest Gradle 8.1.1 version and Android Gradle Plugin 8.0 version, that we are starting to use on projects.

I am not sure how (if even) I could test this locally on Mac. I tried and then gave up, since I would need to change probably a lot stuff in the Dockerfile and I am 100% noob with Docker, so YOLO :D I think it should not break anything, since Java should be used for Gradle run only I think.