### PR TITLE
Make OWASP dependency check plugin work

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.0] - 2024-02-23
+### Add
+- env variable to make Dependency-Check plugin work
+
 ## [v2.0.0] - 2023-05-22
 ### Changed
 - Debian `stretch` to `buster` due to apt mirror missing packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,4 +116,11 @@ RUN flutter config --no-analytics \
   && flutter doctor \
   && flutter update-packages
 
+# Dependency-Check Gradle plugin
+#
+# We use this Gradle plugin https://github.com/jeremylong/DependencyCheck for checking vulnerabilities in our dependencies, but it relies
+# on env variable to determine encoding for dependency parsing, so we need to set this variable to make the task work as discussed and described more
+# here https://github.com/jeremylong/DependencyCheck/issues/1742
+ENV LC_ALL C.UTF-8
+
 VOLUME /root/.gradle


### PR DESCRIPTION
We want to use some Gradle plugin for checking vulnerabilities in our dependencies, but this plugin relies on some env variable to determine encoding for dependency parsing, so we need to set encoding to UTF-8 to make it work.

I built the Docker image locally and tested this change.